### PR TITLE
lookup selected: make dictionary provider configurable

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,8 @@ const
   open = require('open'),
   vscode = require('vscode'),
   window = vscode.window,
-  DEFAULT_ALTER_VISTA_KEY = '3DqZ2Rl83LUbFAAw8SOz';
+  DEFAULT_ALTER_VISTA_KEY = '3DqZ2Rl83LUbFAAw8SOz',
+  DEFAULT_LOOKUP_SELECTED_URL = 'https://www.bing.com/search?q=define%20';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -18,8 +19,9 @@ function activate(context) {
     open(`https://translate.google.com/#${encodeURI(configuration.translateFromLanguage)}/${encodeURI(configuration.translateToLanguage)}/${encodeURI(getSelectedText(textEditor))}`);
   }));
 
-  context.subscriptions.push(vscode.commands.registerTextEditorCommand('dictionary.bing.lookupSelected', (textEditor, edit) => {
-    open(`https://www.bing.com/search?q=${encodeURI(`define ${getSelectedText(textEditor)}`)}`);
+  context.subscriptions.push(vscode.commands.registerTextEditorCommand('dictionary.lookupSelected', (textEditor, edit) => {
+    const lookupURL = vscode.workspace.getConfiguration('dictionary.lookupSelected').lookupURL || DEFAULT_LOOKUP_SELECTED_URL;
+    open(lookupURL + encodeURI(getSelectedText(textEditor)));
   }));
 
   context.subscriptions.push(vscode.commands.registerTextEditorCommand('dictionary.thesaurus.lookupSelectedSynonyms', (textEditor, edit) => {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:dictionary.bing.lookupSelected",
+    "onCommand:dictionary.lookupSelected",
     "onCommand:dictionary.google.translateSelected",
     "onCommand:dictionary.thesaurus.lookupSelectedSynonyms",
     "onCommand:dictionary.alterVista.replaceSelectedWithSynonyms"
@@ -34,8 +34,8 @@
   "contributes": {
     "commands": [
       {
-        "command": "dictionary.bing.lookupSelected",
-        "title": "Dictionary: Lookup definitions of selected words with Bing Translator"
+        "command": "dictionary.lookupSelected",
+        "title": "Dictionary: Lookup definitions of selected words"
       },
       {
         "command": "dictionary.google.translateSelected",
@@ -52,8 +52,14 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "Dictionary configuration",
+      "title": "Dictionary Lookup",
       "properties": {
+        "dictionary.lookupSelected.lookupURL": {
+          "type": "string",
+          "format": "uri",
+          "default": "",
+          "description": "The URL for dictionary lookup. The word will be appended to the URL. Defaulted to Bing."
+        },
         "dictionary.google.translateFromLanguage": {
           "type": "string",
           "default": "auto",


### PR DESCRIPTION
Closes #3 

For definition lookup, make the URL of the dictionary configurable. 

An user can set it to google by entering `https://www.google.com/search?q=define%20` 

![image](https://user-images.githubusercontent.com/250644/90674959-b60dd200-e20e-11ea-9818-6ff44c87b0cf.png)
